### PR TITLE
Bump scalapb 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ credentials from `password`, named `issues.sonatype.org` and then run
 ```bash
 JAVA_OPTS="-Xmx4g" sbt "publish"
 ```
+
+## Sonatype OSS info
+[This ticket](https://issues.sonatype.org/browse/OSSRH-39900) has the history of how the sonatype account was created.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # fhirproto
 scala case classes generated from github.com/google/fhir
+
+# Publishing new versions of this library
+## Locally
+Simply run
+```bash
+JAVA_OPTS="-Xmx4g" sbt "publishLocal"
+```
+
+## Public
+First, create a PR and have it reviewed. Once the PR is accepted, 
+open the `build.sbt` file, and update the `Sonatype username` and `Sonatype password` with 
+credentials from `password`, named `issues.sonatype.org` and then run 
+
+```bash
+JAVA_OPTS="-Xmx4g" sbt "publish"
+```

--- a/build.sbt
+++ b/build.sbt
@@ -57,3 +57,9 @@ publishTo := {
 }
 
 lazy val root = project.in(file("."))
+
+credentials += Credentials("Sonatype Nexus Repository Manager",
+        "oss.sonatype.org",
+        "Sonatype username",
+        "Sonatype password")
+

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Path.{flat, relativeTo}
 
 name := "fhirproto"
 
-version := "0.0.4-SNAPSHOT"
+version := "0.0.5-SNAPSHOT"
 
 scalaVersion := "2.12.6"
 

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.3")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.1"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.2"

--- a/protobuf/proto/stu3/annotations.proto
+++ b/protobuf/proto/stu3/annotations.proto
@@ -22,6 +22,12 @@ option java_outer_classname = "Annotations";
 option java_package = "com.carbonhealth.fhir.stu3.proto";
 
 import "google/protobuf/descriptor.proto";
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
+
 
 // TODO(sundberg): Unify with StructureDefinitionKindCode
 enum StructureDefinitionKindValue {

--- a/protobuf/proto/stu3/base64_separator_stride.proto
+++ b/protobuf/proto/stu3/base64_separator_stride.proto
@@ -21,6 +21,11 @@ option java_package = "com.carbonhealth.fhir.stu3.proto";
 
 import "proto/stu3/annotations.proto";
 import "proto/stu3/datatypes.proto";
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
 
 // This is a Google extension described by
 // https://g.co/fhir/StructureDefinition/base64Binary-separatorStride

--- a/protobuf/proto/stu3/codes.proto
+++ b/protobuf/proto/stu3/codes.proto
@@ -18,6 +18,11 @@ package google.fhir.stu3.proto;
 
 import "proto/stu3/annotations.proto";
 import "proto/stu3/datatypes.proto";
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
 
 option java_multiple_files = true;
 option java_package = "com.carbonhealth.fhir.stu3.proto";

--- a/protobuf/proto/stu3/datatypes.proto
+++ b/protobuf/proto/stu3/datatypes.proto
@@ -17,6 +17,11 @@ syntax = "proto3";
 package google.fhir.stu3.proto;
 
 import "proto/stu3/annotations.proto";
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
 
 option java_multiple_files = true;
 option java_package = "com.carbonhealth.fhir.stu3.proto";

--- a/protobuf/proto/stu3/elementdefinition_binding_name.proto
+++ b/protobuf/proto/stu3/elementdefinition_binding_name.proto
@@ -18,6 +18,11 @@ package google.fhir.stu3.proto;
 
 import "proto/stu3/annotations.proto";
 import "proto/stu3/datatypes.proto";
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
 
 option java_multiple_files = true;
 option java_package = "com.carbonhealth.fhir.stu3.proto";

--- a/protobuf/proto/stu3/metadatatypes.proto
+++ b/protobuf/proto/stu3/metadatatypes.proto
@@ -19,6 +19,11 @@ package google.fhir.stu3.proto;
 import "proto/stu3/annotations.proto";
 import "proto/stu3/codes.proto";
 import "proto/stu3/datatypes.proto";
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
 
 option java_multiple_files = true;
 option java_package = "com.carbonhealth.fhir.stu3.proto";

--- a/protobuf/proto/stu3/primitive_has_no_value.proto
+++ b/protobuf/proto/stu3/primitive_has_no_value.proto
@@ -21,6 +21,11 @@ option java_package = "com.carbonhealth.fhir.stu3.proto";
 
 import "proto/stu3/annotations.proto";
 import "proto/stu3/datatypes.proto";
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
 
 // This is a Google extension described by
 // https://g.co/fhir/StructureDefinition/primitiveHasNoValue

--- a/protobuf/proto/stu3/resources.proto
+++ b/protobuf/proto/stu3/resources.proto
@@ -20,6 +20,11 @@ import "proto/stu3/annotations.proto";
 import "proto/stu3/codes.proto";
 import "proto/stu3/datatypes.proto";
 import "proto/stu3/metadatatypes.proto";
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
 
 option java_multiple_files = true;
 option java_package = "com.carbonhealth.fhir.stu3.proto";

--- a/protobuf/proto/stu3/structuredefinition_explicit_type_name.proto
+++ b/protobuf/proto/stu3/structuredefinition_explicit_type_name.proto
@@ -18,6 +18,11 @@ package google.fhir.stu3.proto;
 
 import "proto/stu3/annotations.proto";
 import "proto/stu3/datatypes.proto";
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
 
 option java_multiple_files = true;
 option java_package = "com.carbonhealth.fhir.stu3.proto";

--- a/protobuf/proto/stu3/structuredefinition_regex.proto
+++ b/protobuf/proto/stu3/structuredefinition_regex.proto
@@ -18,6 +18,11 @@ package google.fhir.stu3.proto;
 
 import "proto/stu3/annotations.proto";
 import "proto/stu3/datatypes.proto";
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
 
 option java_multiple_files = true;
 option java_package = "com.carbonhealth.fhir.stu3.proto";


### PR DESCRIPTION
In order to demo GRPC calls from `api` to `identity` service, we need to bump the scalapb version used here.

You can see the impact of that change in  https://github.com/mdcollab/mdcollab/pull/6347

The generated code is a bit different than before, which is reflected by a few, minor changes that we need to make in the monolith.


